### PR TITLE
[Growth][Feature] Tags releases and New (ETA: 24 August 2021)

### DIFF
--- a/lib/toc_data.rb
+++ b/lib/toc_data.rb
@@ -6,13 +6,27 @@ def toc_data(page_content)
   # get a flat list of headers
   headers = []
   html_doc.css('h1, h2, h3').each do |header|
-    headers.push({
-      id: header.attribute('id').to_s,
-      content: header.children,
-      title: header.children.to_s.gsub(/<[^>]*>/, ''),
-      level: header.name[1].to_i,
-      children: []
-    })
+    if header.attribute('type').to_s == 'beta'
+      idxTrim = header.children.to_s.index("<span")
+      content = header.children.to_s[0,idxTrim] + "<span class='tags beta'>BETA</span>" 
+      headers.push({
+        id: header.attribute('id').to_s,
+        content: content,
+        title: header.children.to_s.gsub(/<[^>]*>/, ''),
+        level: header.name[1].to_i,
+        releases: true,
+        children: []
+      })
+    else
+      headers.push({
+        id: header.attribute('id').to_s,
+        content: header.children,
+        title: header.children.to_s.gsub(/<[^>]*>/, ''),
+        level: header.name[1].to_i,
+        releases: false,
+        children: []
+      })
+    end
   end
 
   [3,2].each do |header_level|

--- a/lib/unique_head.rb
+++ b/lib/unique_head.rb
@@ -9,6 +9,20 @@ class UniqueHeadCounter < Middleman::Renderers::MiddlemanRedcarpetHTML
   end
   def header(text, header_level)
     friendly_text = text.gsub(/<[^>]*>/,"").parameterize
+    if(friendly_text.include? "release-")
+      idxTrim = friendly_text.index('release-')
+      friendly_text = friendly_text[0, idxTrim]
+      if friendly_text[friendly_text.length-1] == '-'
+        friendly_text = friendly_text[0, friendly_text.length-1]
+      end
+    end
+    if(friendly_text.include? "new")
+      idxTrim = friendly_text.index('new')
+      friendly_text = friendly_text[0, idxTrim]
+      if friendly_text[friendly_text.length-1] == '-'
+        friendly_text = friendly_text[0, friendly_text.length-1]
+      end
+    end
     if friendly_text.strip.length == 0
       # Looks like parameterize removed the whole thing! It removes many unicode
       # characters like Chinese and Russian. To get a unique URL, let's just
@@ -28,6 +42,17 @@ class UniqueHeadCounter < Middleman::Renderers::MiddlemanRedcarpetHTML
     if @head_count[friendly_text] > 1
       friendly_text += "-#{@head_count[friendly_text]}"
     end
-    return "<h#{header_level} id='#{friendly_text}'>#{text}</h#{header_level}>"
+    if(text.include? "RELEASE")
+      idxTrim = text.index("RELEASE-")
+      content = text[0,idxTrim]
+      releaseDate = text[idxTrim+"RELEASE-".length, text.length]
+      return "<h#{header_level} id='#{friendly_text}' type='beta'>#{content} <span class='tags beta'>release on #{releaseDate}</span> </h#{header_level}>"
+    elsif(text.include? "NEW")
+      idxTrim = text.index("NEW")
+      content = text[0,idxTrim]
+      return "<h#{header_level} id='#{friendly_text}' type='new'>#{content} <span class='tags new'>NEW</span> </h#{header_level}>"
+    else
+      return "<h#{header_level} id='#{friendly_text}' type='normal'>#{text}</h#{header_level}>"
+    end
   end
 end

--- a/source/layouts/layout.erb
+++ b/source/layouts/layout.erb
@@ -122,9 +122,11 @@ under the License.
         <% toc_data(page_content).each do |h1| %>
           <li>
             <a href="#<%= h1[:id] %>" class="toc-h1 toc-link" data-title="<%= h1[:title] %>">
-              <span>
+              <span class="toc-link-content-image">
                 <%=image_tag h1[:id]+'.svg' %>
-                <%= h1[:content] %>
+                <span class="toc-link-content">
+                  <%= h1[:content] %>
+                </span>
               </span>
               <% if h1[:children].length > 0 %>
                 <%= image_tag "arrow-bottom.svg",  class: 'icon-arrow' %>
@@ -137,10 +139,13 @@ under the License.
                 <% h1[:children].each do |h2| %>
                   <li>
                     <a href="#<%= h2[:id] %>" class="toc-h2 toc-link" data-title="<%= h2[:title] %>">
+                      <span class="toc-link-content">
+                        <%= h2[:content] %>
+                      </span>
                       <% if h2[:children].length > 0 %>
-                        <%= h2[:content] %> <%= image_tag "arrow-bottom.svg", class: 'active-parent icon-arrow'%>
+                         <%= image_tag "arrow-bottom.svg", class: 'active-parent icon-arrow'%>
                       <% else %>
-                        <%= h2[:content] %> <%= image_tag "arrow-right.svg", class: 'icon-arrow'%>
+                        <%= image_tag "arrow-right.svg", class: 'icon-arrow'%>
                       <% end %>
                     </a>
                    <% if h2[:children].length > 0 %>
@@ -148,7 +153,10 @@ under the License.
                       <% h2[:children].each do |h3| %>
                         <li>
                           <a href="#<%= h3[:id] %>" class="toc-h3 toc-link" data-title="<%= h3[:title] %>">
-                            <%= h3[:content] %> <%= image_tag "arrow-right.svg", class: 'icon-arrow'%>
+                            <span class="toc-link-content">
+                              <%= h3[:content] %>
+                            </span> 
+                            <%= image_tag "arrow-right.svg", class: 'icon-arrow'%>
                           </a>
                         </li>
                       <% end %>

--- a/source/stylesheets/screen.css.scss
+++ b/source/stylesheets/screen.css.scss
@@ -39,6 +39,22 @@ html, body {
 ////////////////////////////////////////////////////////////////////////////////
 // TABLE OF CONTENTS
 ////////////////////////////////////////////////////////////////////////////////
+.tags{
+  font-size: 12px;
+  line-height: 16px;
+  text-align: center;
+  padding: 4px 8px;
+  color: white;
+  border-radius: 4px;
+  text-transform: capitalize;
+  font-weight: normal;
+  &.beta{
+    background-color: #F38827;
+  }
+  &.new{
+    background-color: #0D47A1;
+  }
+}
 
 .search {
   position: relative;
@@ -345,19 +361,32 @@ html, body {
     }
   }
 
-  // This is the currently selected ToC entry
-  .toc-link.active {
-    background-color: $nav-active-bg;
-    color: $nav-active-text;
-    border-radius: 10px;
-    &:hover{
-      color: lighten($color: $main-color, $amount: 10);
+  .toc-link{
+    // This is the currently selected ToC entry
+    &.active {
+      background-color: $nav-active-bg;
+      color: $nav-active-text;
+      border-radius: 10px;
+      &:hover{
+        color: lighten($color: $main-color, $amount: 10);
+      }
     }
-  }
-  // this is parent links of the currently selected ToC entry
-  .toc-link.active-parent {
-    background-color: $nav-active-parent-bg;
-    color: $nav-active-parent-text;
+    // this is parent links of the currently selected ToC entry
+    &.active-parent {
+      background-color: $nav-active-parent-bg;
+      color: $nav-active-parent-text;
+    }
+    .toc-link-content{
+      flex:1;
+      display: flex;
+      justify-content: space-between;
+      align-items: center;
+    }
+    .toc-link-content-image{
+      width: 100%;
+      display: grid;
+      grid-template-columns: auto 1fr;
+    }
   }
 
   .toc-list-h2 {
@@ -831,6 +860,13 @@ html, body {
 // These are the styles for phones and tablets
 // There are also a couple styles disperesed
 @media (max-width: $desktop-width){
+  .content{
+    &>h1, &>h2, &>h3, &>h4, &>h5, &>h6 {
+      display: flex;
+      flex-direction: column;
+      align-items: flex-start;
+    }
+  }
   .header{
     &-logo {
       &-container{


### PR DESCRIPTION
### Background
This task related to: https://app.clickup.com/t/bv49mb
Add tags in header (Releases and New). Now, document creator can add tags "releases" and "new" in their document. Usage of this tags is very simple, you just add in Header keyword "RELEASES:<date>" for tags "releases" and also keyword "NEW" for tags tags "new".
![image](https://user-images.githubusercontent.com/32569977/130391255-938ab0c5-ae08-4746-ad14-2962ff8b0d31.png)

### How to Test
- In header, add keyword "RELEASES:<date>" or "NEW". It will generate in document and also in TOC.

### Note
- Need to create a new documentation about how to write document (tutorial.md)
- New tags is hard coded

### Test
- [ ] Tested in Dev
- [ ] Tested by PM in Dev