### PR TITLE
Add cc staging dummy card details 

### DIFF
--- a/source/includes/_accepting-payments.md
+++ b/source/includes/_accepting-payments.md
@@ -495,6 +495,18 @@ During testing, you can set the transaction amount to a certain mock value to si
 | QRIS                 | Failure during refund process                                                                                                                                            | Amount is less than 55,000 or greater than 66,000 | Refund Failed     |
 | E-Wallet - LinkAja   | Failure during refund process                                                                                                                                            | Amount is less than 55,000 or greater than 66,000 | Refund Failed     |
 
+
+**Mock Credentials for Testing**
+Specifically for payment via Credit Card or Debit Card, you may use the below credentials to simulate payment for a successful transaction in staging environment
+
+| Card Details          | Values                     |
+| ----------------------| ---------------------------|
+|Card Number            | 2223000000000007           |
+|Card Expired Month/Year| 01/39                      |
+|Card CVN               | 100                        |
+|Card Holder Name       | Testing                    |
+
+
 ### How to Use Payment Link via Dashboard
 
 One-time Link


### PR DESCRIPTION
this update is to add CC/DC staging credentials in our Product Docs

<!--
⚠️ 🚨 ⚠️  STOP AND READ THIS ⚠️ 🚨 ⚠️

👆👆 see that 'base fork' dropdown above? You should change it! The default value of "slatedocs/slate" submits your change to ALL USERS OF SLATE, not just your company. This is PROBABLY NOT WHAT YOU WANT.
-->